### PR TITLE
fix the end extend of actions in dismiss animation

### DIFF
--- a/lib/src/widgets/slidable.dart
+++ b/lib/src/widgets/slidable.dart
@@ -173,8 +173,7 @@ class SlideToDismissDrawerDelegate extends SlideToDismissDelegate {
               final extentAnimations = Iterable.generate(count).map((index) {
                 return new Tween(
                   begin: actionExtent,
-                  end: totalExtent -
-                      (actionExtent * (ctx.state.actionCount - index)),
+                  end: totalExtent,
                 ).animate(
                   new CurvedAnimation(
                     parent: ctx.state.overallMoveAnimation,

--- a/lib/src/widgets/slidable.dart
+++ b/lib/src/widgets/slidable.dart
@@ -173,7 +173,8 @@ class SlideToDismissDrawerDelegate extends SlideToDismissDelegate {
               final extentAnimations = Iterable.generate(count).map((index) {
                 return new Tween(
                   begin: actionExtent,
-                  end: totalExtent,
+                  end: totalExtent -
+                      (actionExtent * (ctx.state.actionCount - index)),
                 ).animate(
                   new CurvedAnimation(
                     parent: ctx.state.overallMoveAnimation,

--- a/lib/src/widgets/slidable.dart
+++ b/lib/src/widgets/slidable.dart
@@ -173,7 +173,8 @@ class SlideToDismissDrawerDelegate extends SlideToDismissDelegate {
               final extentAnimations = Iterable.generate(count).map((index) {
                 return new Tween(
                   begin: actionExtent,
-                  end: totalExtent - (actionExtent * (ctx.state.actionCount - index - 1)),
+                  end: totalExtent -
+                      (actionExtent * (ctx.state.actionCount - index - 1)),
                 ).animate(
                   new CurvedAnimation(
                     parent: ctx.state.overallMoveAnimation,

--- a/lib/src/widgets/slidable.dart
+++ b/lib/src/widgets/slidable.dart
@@ -173,7 +173,7 @@ class SlideToDismissDrawerDelegate extends SlideToDismissDelegate {
               final extentAnimations = Iterable.generate(count).map((index) {
                 return new Tween(
                   begin: actionExtent,
-                  end: totalExtent,
+                  end: totalExtent - (actionExtent * (ctx.state.actionCount - index - 1)),
                 ).animate(
                   new CurvedAnimation(
                     parent: ctx.state.overallMoveAnimation,


### PR DESCRIPTION
The end extend of secondary actions must be smaller, since their position is not at the same point as the primary action (ie. the Offset zero).

### **_before:_**
![dismiss_before](https://user-images.githubusercontent.com/44171190/46967501-ffd87f00-d0b0-11e8-82e5-5a5152500f83.gif)
### **_after:_**
![dismiss_after](https://user-images.githubusercontent.com/44171190/46967571-37472b80-d0b1-11e8-9d04-ac3e65440d7d.gif)

A workaround would be to wrap the ListTile with a Container and set a color.

