### PR TITLE
Enable fast/strong/fling swipe to close a pinned actions.

### DIFF
--- a/lib/src/widgets/slidable.dart
+++ b/lib/src/widgets/slidable.dart
@@ -1015,8 +1015,7 @@ class SlidableState extends State<Slidable>
 
     if (dismissible && overallMoveAnimation.value > totalActionsExtent) {
       // We are in a dismiss state.
-      if (overallMoveAnimation.value >= dismissThreshold ||
-        (shouldOpen && fast)) {
+      if (overallMoveAnimation.value >= dismissThreshold || fast) {
         dismiss();
       } else {
         open();

--- a/lib/src/widgets/slidable.dart
+++ b/lib/src/widgets/slidable.dart
@@ -1020,8 +1020,8 @@ class SlidableState extends State<Slidable>
       } else {
         open();
       }
-    } else if (actionsMoveAnimation.value >= widget.showAllActionsThreshold ||
-        (shouldOpen && fast)) {
+    } else if ((actionsMoveAnimation.value >= widget.showAllActionsThreshold ||
+        (shouldOpen && fast)) && !(!shouldOpen && fast)) {
       open();
     } else {
       close();

--- a/lib/src/widgets/slidable.dart
+++ b/lib/src/widgets/slidable.dart
@@ -588,7 +588,7 @@ class SlidableDrawerDelegate extends SlidableStackDelegate {
   }
 }
 
-/// A controller that keep tracks of the active [SlidableState] and close
+/// A controller that keeps tracks of the active [SlidableState] and closes
 /// the previous one.
 class SlidableController {
   SlidableController({
@@ -1015,7 +1015,8 @@ class SlidableState extends State<Slidable>
 
     if (dismissible && overallMoveAnimation.value > totalActionsExtent) {
       // We are in a dismiss state.
-      if (overallMoveAnimation.value >= dismissThreshold) {
+      if (overallMoveAnimation.value >= dismissThreshold ||
+        (shouldOpen && fast)) {
         dismiss();
       } else {
         open();


### PR DESCRIPTION
fastThreshold is also used to close pinned items. It follows the same pattern that is set for opening the actions.