### PR TITLE
Hide IconSlideAction text if it's empty.

### DIFF
--- a/lib/src/widgets/slide_action.dart
+++ b/lib/src/widgets/slide_action.dart
@@ -131,14 +131,17 @@ class IconSlideAction extends ClosableSlideAction {
         ThemeData.estimateBrightnessForColor(color) == Brightness.light
             ? Colors.black
             : Colors.white;
-    final Text textWidget = new Text(
-      caption ?? '',
-      overflow: TextOverflow.ellipsis,
-      style: Theme.of(context)
-          .primaryTextTheme
-          .caption
-          .copyWith(color: foregroundColor ?? estimatedColor),
-    );
+    Widget textWidget = Container(width: 0, height: 0);
+    if (caption != null) {
+      textWidget = new Text(
+        caption,
+        overflow: TextOverflow.ellipsis,
+        style: Theme.of(context)
+            .primaryTextTheme
+            .caption
+            .copyWith(color: foregroundColor ?? estimatedColor),
+      );
+    }
     return Container(
       color: color,
       child: new Center(


### PR DESCRIPTION
This will make icon centered inside widget, where previously empty text label was still taking space.