### PR TITLE
Fix NPE on widget.dismissal

### DIFF
--- a/lib/src/widgets/slidable.dart
+++ b/lib/src/widgets/slidable.dart
@@ -558,8 +558,13 @@ class SlidableState extends State<Slidable>
 
   double get _totalActionsExtent => widget.actionExtentRatio * (_actionCount);
 
-  double get _dismissThreshold =>
-      widget.dismissal?.dismissThresholds[actionType] ?? _kDismissThreshold;
+  double get _dismissThreshold {
+    if (widget.dismissal == null) {
+      return _kDismissThreshold;
+    }
+    return widget.dismissal?.dismissThresholds[actionType] ??
+        _kDismissThreshold;
+  }
 
   bool get _dismissible => widget.dismissal != null && _dismissThreshold < 1.0;
 


### PR DESCRIPTION
Have slidable without dismissal and getting NPE on widget build. Tried adding another ? between widget.dismissal but it still threw an exception. Not sure why the ?. notation isn't forwarding to the ?? default. Running Flutter 1.5.4-hotfix.2

Here's the stack:
I/flutter (21909): 2019-05-16 12:58:48.815964 WARNING [Flutter] NoSuchMethodError: The method '[]' was called on null.
I/flutter (21909): Receiver: null
I/flutter (21909): Tried calling: [](Instance of 'SlideActionType')
I/flutter (21909): #0      Object.noSuchMethod  (dart:core-patch/object_patch.dart:50:5)
I/flutter (21909): #1      SlidableState._dismissThreshold
package:flutter_slidable/…/widgets/slidable.dart:562
I/flutter (21909): #2      SlidableState.build
package:flutter_slidable/…/widgets/slidable.dart:897