### PR TITLE
Add an option to make the widget non-dismissible by dragging

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ The `open` method has an optional parameter called `actionType` that let you cho
 
 Similar to opening or closing, you can dismiss the `Slidable` programmatically by calling the `dismiss` method of the `SlidableState`.
 
+If you want to use the `dismiss` method without allowing your user to slide to dismiss, you can set the `dragDismissible` parameter of the `SlidableDismissal` constructor to `false`.
+
 ## Changelog
 
 Please see the [Changelog](https://github.com/letsar/flutter_slidable/blob/master/CHANGELOG.md) page to know what's recently changed.

--- a/README.md
+++ b/README.md
@@ -269,6 +269,10 @@ The easiest way get the `SlidableState` from a child is to call `Slidable.of(con
 
 The `open` method has an optional parameter called `actionType` that let you choose which action pane to open.
 
+#### How can I dismiss the Slidable programmatically?
+
+Similar to opening or closing, you can dismiss the `Slidable` programmatically by calling the `dismiss` method of the `SlidableState`.
+
 ## Changelog
 
 Please see the [Changelog](https://github.com/letsar/flutter_slidable/blob/master/CHANGELOG.md) page to know what's recently changed.

--- a/lib/src/widgets/slidable.dart
+++ b/lib/src/widgets/slidable.dart
@@ -713,8 +713,15 @@ class SlidableState extends State<Slidable>
           ? SlideActionType.primary
           : SlideActionType.secondary;
       if (_actionCount > 0) {
-        _overallMoveController.value =
-            _dragExtent.abs() / _overallDragAxisExtent;
+        if (_dismissible && !widget.dismissal.dragDismissible) {
+          // If the widget is not dismissible by dragging, clamp drag result
+          // so the widget doesn't slide past [_totalActionsExtent].
+          _overallMoveController.value = (_dragExtent.abs() / _overallDragAxisExtent)
+              .clamp(0.0, _totalActionsExtent);
+        } else {
+          _overallMoveController.value =
+              _dragExtent.abs() / _overallDragAxisExtent;
+        }
       }
     });
   }

--- a/lib/src/widgets/slidable_dismissal.dart
+++ b/lib/src/widgets/slidable_dismissal.dart
@@ -26,7 +26,16 @@ class SlidableDismissal extends StatelessWidget {
     this.crossAxisEndOffset = 0.0,
     this.onWillDismiss,
     this.closeOnCanceled = false,
+    this.dragDismissible = true,
   }) : assert(dismissThresholds != null);
+
+  /// Specifies if the widget can be dismissed by sliding.
+  ///
+  /// Setting to false makes the widget dismissible only by
+  /// calling [Slidable.dismiss()].
+  ///
+  /// Defaults to true.
+  final bool dragDismissible;
 
   /// The offset threshold the item has to be dragged in order to be considered
   /// dismissed.


### PR DESCRIPTION
Implementation of the feature requested in #63. Allows to call `SlidableState.dismiss()` and use the dismissal animation without allowing a user to dismiss manually by sliding.