### PR TITLE
Fix actionType setter

### DIFF
--- a/lib/src/widgets/slidable.dart
+++ b/lib/src/widgets/slidable.dart
@@ -598,6 +598,7 @@ class SlidableState extends State<Slidable>
   SlideActionType _actionType = SlideActionType.primary;
   SlideActionType get actionType => _actionType;
   set actionType(SlideActionType value) {
+    if (_actionType == value) return;
     _actionType = value;
     _initAnimations();
   }


### PR DESCRIPTION
Hi!

Calling to _initAnimations on each movement (_handleDragUpdate) is TOO expensive and leads to freezes after a certain amount of movements (about few tens).

```
  @override
  Widget build(BuildContext context)
  {
    return Scaffold(
      appBar: AppBar(
        title: Text(L10n.of(context).ordersPageTitle),
      ),
      body: Center(
        child: SizedBox(
          height: 100,
          child: Slidable(
            actionPane: SlidableDrawerActionPane(),
            actionExtentRatio: 0.2,
            secondaryActions: <Widget>[
              IconSlideAction(
                caption: 'Edit',
                color: Colors.lime,
                icon: Icons.edit,
                onTap: () {
                },
              ),
              IconSlideAction(
                caption: 'Delete',
                color: Colors.red,
                icon: Icons.cancel,
                onTap: () {
                },
              ),
            ],
            direction: Axis.horizontal,
            child: Container(
              color: Colors.white,
              child: Center(
                child: Text('Caption'),
              ),
            ),
          )
        )
      )
    );
  }
```
![Screenrecorder-2020-08-15-12-18-34-556](https://user-images.githubusercontent.com/3534966/90309624-d67a1b80-def2-11ea-8b43-7e909165a239.gif)
