### PR TITLE
Made closing the action items smoother

### DIFF
--- a/lib/src/widgets/slidable.dart
+++ b/lib/src/widgets/slidable.dart
@@ -802,6 +802,10 @@ class SlidableState extends State<Slidable>
       } else {
         open();
       }
+    } else if ((_actionType == SlideActionType.secondary &&
+            velocity.sign > 0) ||
+        (_actionType == SlideActionType.primary && velocity.sign < 0)) {
+      close();
     } else if (_actionsMoveAnimation!.value >= widget.showAllActionsThreshold ||
         (shouldOpen && fast)) {
       open();


### PR DESCRIPTION
Right now opening the action items can get very smooth with the `showAllActionsThreshold` parameter, however closing the items requires a full swipe.

In this PR, I have made closing action items smoother. 