### PR TITLE
Fix bug Field 'lastPosition' has not been initialized when pressed

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/gesture_detector.dart
+++ b/lib/src/gesture_detector.dart
@@ -90,14 +90,17 @@ class _SlidableGestureDetectorState extends State<SlidableGestureDetector> {
   }
 
   void handleDragEnd(DragEndDetails details) {
-    final delta = lastPosition - startPosition;
-    final primaryDelta = directionIsXAxis ? delta.dx : delta.dy;
-    final gestureDirection =
-        primaryDelta >= 0 ? GestureDirection.opening : GestureDirection.closing;
+    try {
+      final delta = lastPosition - startPosition;
+      final primaryDelta = directionIsXAxis ? delta.dx : delta.dy;
+      final gestureDirection = primaryDelta >= 0
+          ? GestureDirection.opening
+          : GestureDirection.closing;
 
-    widget.controller.dispatchEndGesture(
-      details.primaryVelocity,
-      gestureDirection,
-    );
+      widget.controller.dispatchEndGesture(
+        details.primaryVelocity,
+        gestureDirection,
+      );
+    } catch (_) {}
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -192,7 +192,7 @@ packages:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.13"
+    version: "2.0.1"
   package_config:
     dependency: transitive
     description:
@@ -281,7 +281,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -316,21 +316,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.5"
+    version: "1.16.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.15"
+    version: "0.3.19"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
When the user pressed (not drag item) this error occurs

```
════════ Exception caught by gesture ═══════════════════════════════════════════
The following LateError was thrown while handling a gesture:
LateInitializationError: Field 'lastPosition' has not been initialized.

When the exception was thrown, this was the stack
#0      _SlidableGestureDetectorState.lastPosition (package:flutter_slidable/src/gesture_detector.dart)
package:flutter_slidable/src/gesture_detector.dart:1
#1      _SlidableGestureDetectorState.handleDragEnd
package:flutter_slidable/src/gesture_detector.dart:93
#2      DragGestureRecognizer._checkEnd.<anonymous closure>
package:flutter/…/gestures/monodrag.dart:473
#3      GestureRecognizer.invokeCallback
package:flutter/…/gestures/recognizer.dart:182
#4      DragGestureRecognizer._checkEnd
package:flutter/…/gestures/monodrag.dart:473
...
Handler: "onEnd"
Recognizer: HorizontalDragGestureRecognizer#c5a3b
    debugOwner: GestureDetector
    start behavior: down
════════════════════════════════════════════════════════════════════════════════
Application finished.
```