### PR TITLE
SlidableAction allow customize to [label, icon, shape, side and margin]

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -28,51 +28,78 @@ class MyApp extends StatelessWidget {
                 dismissible: DismissiblePane(onDismissed: () {}),
 
                 // All actions are defined in the children parameter.
-                children: const [
+                children: [
                   // A SlidableAction can have an icon and/or a label.
                   SlidableAction(
                     onPressed: doNothing,
-                    backgroundColor: Color(0xFFFE4A49),
+                    backgroundColor: const Color(0xFFFE4A49),
                     foregroundColor: Colors.white,
-                    icon: Icons.delete,
+                    icon: const Icon(Icons.delete),
                     label: 'Delete',
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    margin: const EdgeInsets.symmetric(horizontal: 2),
                   ),
                   SlidableAction(
                     onPressed: doNothing,
-                    backgroundColor: Color(0xFF21B7CA),
+                    backgroundColor: const Color(0xFF21B7CA),
                     foregroundColor: Colors.white,
-                    icon: Icons.share,
+                    icon: const Icon(Icons.share),
                     label: 'Share',
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    margin: const EdgeInsets.symmetric(horizontal: 2),
                   ),
                 ],
               ),
 
               // The end action pane is the one at the right or the bottom side.
-              endActionPane: const ActionPane(
-                motion: ScrollMotion(),
+              endActionPane: ActionPane(
+                motion: const ScrollMotion(),
                 children: [
                   SlidableAction(
                     // An action can be bigger than the others.
-                    flex: 2,
                     onPressed: doNothing,
-                    backgroundColor: Color(0xFF7BC043),
+                    backgroundColor: const Color(0xFF7BC043),
                     foregroundColor: Colors.white,
-                    icon: Icons.archive,
+                    icon: const Icon(Icons.archive),
                     label: 'Archive',
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    margin: const EdgeInsets.symmetric(horizontal: 2),
                   ),
                   SlidableAction(
                     onPressed: doNothing,
-                    backgroundColor: Color(0xFF0392CF),
+                    backgroundColor: const Color(0xFF0392CF),
                     foregroundColor: Colors.white,
-                    icon: Icons.save,
+                    icon: const Icon(Icons.save),
                     label: 'Save',
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    margin: const EdgeInsets.symmetric(horizontal: 2),
                   ),
                 ],
               ),
 
               // The child of the Slidable is what the user sees when the
               // component is not dragged.
-              child: const ListTile(title: Text('Slide me')),
+              child: Container(
+                margin: const EdgeInsets.symmetric(horizontal: 2),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(4),
+                  color: Colors.teal,
+                ),
+                child: const ListTile(
+                  title: Text(
+                    'Slide me',
+                    style: TextStyle(color: Colors.white),
+                  ),
+                ),
+              ),
             ),
             Slidable(
               // Specify a key if the Slidable is dismissible.
@@ -90,14 +117,14 @@ class MyApp extends StatelessWidget {
                     onPressed: doNothing,
                     backgroundColor: Color(0xFFFE4A49),
                     foregroundColor: Colors.white,
-                    icon: Icons.delete,
+                    icon: Icon(Icons.delete),
                     label: 'Delete',
                   ),
                   SlidableAction(
                     onPressed: doNothing,
                     backgroundColor: Color(0xFF21B7CA),
                     foregroundColor: Colors.white,
-                    icon: Icons.share,
+                    icon: Icon(Icons.share),
                     label: 'Share',
                   ),
                 ],
@@ -114,14 +141,14 @@ class MyApp extends StatelessWidget {
                     onPressed: doNothing,
                     backgroundColor: Color(0xFF7BC043),
                     foregroundColor: Colors.white,
-                    icon: Icons.archive,
+                    icon: Icon(Icons.archive),
                     label: 'Archive',
                   ),
                   SlidableAction(
                     onPressed: doNothing,
                     backgroundColor: Color(0xFF0392CF),
                     foregroundColor: Colors.white,
-                    icon: Icons.save,
+                    icon: Icon(Icons.save),
                     label: 'Save',
                   ),
                 ],

--- a/example/lib/main_demo.dart
+++ b/example/lib/main_demo.dart
@@ -260,7 +260,7 @@ class SlideAction extends StatelessWidget {
       backgroundColor: color,
       foregroundColor: Colors.white,
       onPressed: (_) {},
-      icon: icon,
+      icon: Icon(icon),
       label: 'hello',
     );
   }

--- a/example/lib/main_example.dart
+++ b/example/lib/main_example.dart
@@ -218,7 +218,7 @@ class SlideAction extends StatelessWidget {
       backgroundColor: color,
       foregroundColor: Colors.white,
       onPressed: (_) {},
-      icon: icon,
+      icon: Icon(icon),
       label: label,
     );
   }

--- a/example/lib/main_outside_list.dart
+++ b/example/lib/main_outside_list.dart
@@ -201,7 +201,7 @@ class SlideAction extends StatelessWidget {
       backgroundColor: color,
       foregroundColor: Colors.white,
       onPressed: (_) {},
-      icon: icon,
+      icon: Icon(icon),
       label: 'hello',
     );
   }

--- a/lib/src/actions.dart
+++ b/lib/src/actions.dart
@@ -20,9 +20,12 @@ class CustomSlidableAction extends StatelessWidget {
   const CustomSlidableAction({
     Key? key,
     this.flex = _kFlex,
+    this.margin,
     this.backgroundColor = _kBackgroundColor,
     this.foregroundColor,
     this.autoClose = _kAutoClose,
+    this.shape,
+    this.side,
     required this.onPressed,
     required this.child,
   })  : assert(flex > 0),
@@ -69,6 +72,22 @@ class CustomSlidableAction extends StatelessWidget {
   /// Typically the action's icon or label.
   final Widget child;
 
+  /// {@template slidable.actions.margin}
+  /// Empty space to surround the slidable actions.
+  /// {@endtemplate}
+  final EdgeInsetsGeometry? margin;
+
+  /// {@template slidable.actions.shape}
+  /// [OutlinedBorder] of action, if is null, then [RoundedRectangleBorder]
+  /// used by default
+  /// {@endtemplate}
+  final OutlinedBorder? shape;
+
+  /// {@template slidable.actions.side}
+  /// [BorderSide] of action, if is null, then [BorderSide.none] used by default
+  /// {@endtemplate}
+  final BorderSide? side;
+
   @override
   Widget build(BuildContext context) {
     final effectiveForegroundColor = foregroundColor ??
@@ -79,15 +98,18 @@ class CustomSlidableAction extends StatelessWidget {
 
     return Expanded(
       flex: flex,
-      child: SizedBox.expand(
+      child: Container(
+        margin: margin,
+        width: double.infinity,
+        height: double.infinity,
         child: OutlinedButton(
           onPressed: () => _handleTap(context),
           style: OutlinedButton.styleFrom(
             backgroundColor: backgroundColor,
             primary: effectiveForegroundColor,
             onSurface: effectiveForegroundColor,
-            shape: const RoundedRectangleBorder(),
-            side: BorderSide.none,
+            shape: shape ?? const RoundedRectangleBorder(),
+            side: side ?? BorderSide.none,
           ),
           child: child,
         ),
@@ -116,6 +138,7 @@ class SlidableAction extends StatelessWidget {
   const SlidableAction({
     Key? key,
     this.flex = _kFlex,
+    this.margin,
     this.backgroundColor = _kBackgroundColor,
     this.foregroundColor,
     this.autoClose = _kAutoClose,
@@ -123,6 +146,9 @@ class SlidableAction extends StatelessWidget {
     this.icon,
     this.spacing = 4,
     this.label,
+    this.labelStyle,
+    this.shape,
+    this.side,
   })  : assert(flex > 0),
         assert(icon != null || label != null),
         super(key: key);
@@ -143,24 +169,34 @@ class SlidableAction extends StatelessWidget {
   final SlidableActionCallback? onPressed;
 
   /// An icon to display above the [label].
-  final IconData? icon;
+  final Icon? icon;
 
   /// The space between [icon] and [label] if both set.
   ///
   /// Defaults to 4.
   final double spacing;
 
+  /// Empty space to surround the slidable actions.
+  final EdgeInsetsGeometry? margin;
+
   /// A label to display below the [icon].
   final String? label;
+
+  /// The style to use for the label
+  final TextStyle? labelStyle;
+
+  /// The shape for slidable action
+  final OutlinedBorder? shape;
+
+  /// The side for slidable action
+  final BorderSide? side;
 
   @override
   Widget build(BuildContext context) {
     final children = <Widget>[];
 
     if (icon != null) {
-      children.add(
-        Icon(icon),
-      );
+      children.add(icon!);
     }
 
     if (label != null) {
@@ -174,6 +210,7 @@ class SlidableAction extends StatelessWidget {
         Text(
           label!,
           overflow: TextOverflow.ellipsis,
+          style: labelStyle,
         ),
       );
     }
@@ -192,10 +229,13 @@ class SlidableAction extends StatelessWidget {
           );
 
     return CustomSlidableAction(
+      margin: margin,
       onPressed: onPressed,
       autoClose: autoClose,
       backgroundColor: backgroundColor,
       foregroundColor: foregroundColor,
+      shape: shape,
+      side: side,
       flex: flex,
       child: child,
     );

--- a/test/actions_test.dart
+++ b/test/actions_test.dart
@@ -80,7 +80,7 @@ void main() {
             children: [
               SlidableAction(
                 onPressed: (_) => logs.add('pressed'),
-                icon: Icons.ac_unit,
+                icon: const Icon(Icons.ac_unit),
               )
             ],
           ),
@@ -99,7 +99,7 @@ void main() {
             children: [
               SlidableAction(
                 onPressed: (_) => logs.add('pressed'),
-                icon: Icons.ac_unit,
+                icon: const Icon(Icons.ac_unit),
                 label: 'my_label',
               )
             ],

--- a/test/dismissible_pane_test.dart
+++ b/test/dismissible_pane_test.dart
@@ -34,8 +34,10 @@ void main() {
                   ),
                   motion: const BehindMotion(),
                   children: [
-                    SlidableAction(onPressed: (_) {}, icon: Icons.share),
-                    SlidableAction(onPressed: (_) {}, icon: Icons.delete),
+                    SlidableAction(
+                        onPressed: (_) {}, icon: const Icon(Icons.share)),
+                    SlidableAction(
+                        onPressed: (_) {}, icon: const Icon(Icons.delete)),
                   ],
                 ),
                 child: const SizedBox.expand(),
@@ -77,8 +79,10 @@ void main() {
                   ),
                   motion: const BehindMotion(),
                   children: [
-                    SlidableAction(onPressed: (_) {}, icon: Icons.share),
-                    SlidableAction(onPressed: (_) {}, icon: Icons.delete),
+                    SlidableAction(
+                        onPressed: (_) {}, icon: const Icon(Icons.share)),
+                    SlidableAction(
+                        onPressed: (_) {}, icon: const Icon(Icons.delete)),
                   ],
                 ),
                 child: const SizedBox.expand(),
@@ -124,8 +128,10 @@ void main() {
                   ),
                   motion: const BehindMotion(),
                   children: [
-                    SlidableAction(onPressed: (_) {}, icon: Icons.share),
-                    SlidableAction(onPressed: (_) {}, icon: Icons.delete),
+                    SlidableAction(
+                        onPressed: (_) {}, icon: const Icon(Icons.share)),
+                    SlidableAction(
+                        onPressed: (_) {}, icon: const Icon(Icons.delete)),
                   ],
                 ),
                 child: const SizedBox.expand(),
@@ -176,8 +182,10 @@ void main() {
                   ),
                   motion: const BehindMotion(),
                   children: [
-                    SlidableAction(onPressed: (_) {}, icon: Icons.share),
-                    SlidableAction(onPressed: (_) {}, icon: Icons.delete),
+                    SlidableAction(
+                        onPressed: (_) {}, icon: const Icon(Icons.share)),
+                    SlidableAction(
+                        onPressed: (_) {}, icon: const Icon(Icons.delete)),
                   ],
                 ),
                 child: const SizedBox.expand(),
@@ -232,8 +240,10 @@ void main() {
                   ),
                   motion: const BehindMotion(),
                   children: [
-                    SlidableAction(onPressed: (_) {}, icon: Icons.share),
-                    SlidableAction(onPressed: (_) {}, icon: Icons.delete),
+                    SlidableAction(
+                        onPressed: (_) {}, icon: const Icon(Icons.share)),
+                    SlidableAction(
+                        onPressed: (_) {}, icon: const Icon(Icons.delete)),
                   ],
                 ),
                 child: const SizedBox.expand(),
@@ -290,8 +300,10 @@ void main() {
                   ),
                   motion: const BehindMotion(),
                   children: [
-                    SlidableAction(onPressed: (_) {}, icon: Icons.share),
-                    SlidableAction(onPressed: (_) {}, icon: Icons.delete),
+                    SlidableAction(
+                        onPressed: (_) {}, icon: const Icon(Icons.share)),
+                    SlidableAction(
+                        onPressed: (_) {}, icon: const Icon(Icons.delete)),
                   ],
                 ),
                 child: Builder(

--- a/test/slidable_test.dart
+++ b/test/slidable_test.dart
@@ -21,16 +21,20 @@ void main() {
               key: startActionPaneKey,
               motion: const BehindMotion(),
               children: [
-                SlidableAction(onPressed: (_) {}, icon: Icons.share),
-                SlidableAction(onPressed: (_) {}, icon: Icons.delete),
+                SlidableAction(
+                    onPressed: (_) {}, icon: const Icon(Icons.share)),
+                SlidableAction(
+                    onPressed: (_) {}, icon: const Icon(Icons.delete)),
               ],
             ),
             endActionPane: ActionPane(
               key: endActionPaneKey,
               motion: const ScrollMotion(),
               children: [
-                SlidableAction(onPressed: (_) {}, icon: Icons.share),
-                SlidableAction(onPressed: (_) {}, icon: Icons.delete),
+                SlidableAction(
+                    onPressed: (_) {}, icon: const Icon(Icons.share)),
+                SlidableAction(
+                    onPressed: (_) {}, icon: const Icon(Icons.delete)),
               ],
             ),
             child: Builder(builder: (context) {
@@ -68,16 +72,20 @@ void main() {
               key: startActionPaneKey,
               motion: const BehindMotion(),
               children: [
-                SlidableAction(onPressed: (_) {}, icon: Icons.share),
-                SlidableAction(onPressed: (_) {}, icon: Icons.delete),
+                SlidableAction(
+                    onPressed: (_) {}, icon: const Icon(Icons.share)),
+                SlidableAction(
+                    onPressed: (_) {}, icon: const Icon(Icons.delete)),
               ],
             ),
             endActionPane: ActionPane(
               key: endActionPaneKey,
               motion: const ScrollMotion(),
               children: [
-                SlidableAction(onPressed: (_) {}, icon: Icons.share),
-                SlidableAction(onPressed: (_) {}, icon: Icons.delete),
+                SlidableAction(
+                    onPressed: (_) {}, icon: const Icon(Icons.share)),
+                SlidableAction(
+                    onPressed: (_) {}, icon: const Icon(Icons.delete)),
               ],
             ),
             child: Builder(builder: (context) {
@@ -116,16 +124,20 @@ void main() {
               key: startActionPaneKey,
               motion: const BehindMotion(),
               children: [
-                SlidableAction(onPressed: (_) {}, icon: Icons.share),
-                SlidableAction(onPressed: (_) {}, icon: Icons.delete),
+                SlidableAction(
+                    onPressed: (_) {}, icon: const Icon(Icons.share)),
+                SlidableAction(
+                    onPressed: (_) {}, icon: const Icon(Icons.delete)),
               ],
             ),
             endActionPane: ActionPane(
               key: endActionPaneKey,
               motion: const ScrollMotion(),
               children: [
-                SlidableAction(onPressed: (_) {}, icon: Icons.share),
-                SlidableAction(onPressed: (_) {}, icon: Icons.delete),
+                SlidableAction(
+                    onPressed: (_) {}, icon: const Icon(Icons.share)),
+                SlidableAction(
+                    onPressed: (_) {}, icon: const Icon(Icons.delete)),
               ],
             ),
             child: Builder(builder: (context) {
@@ -164,16 +176,20 @@ void main() {
               key: startActionPaneKey,
               motion: const BehindMotion(),
               children: [
-                SlidableAction(onPressed: (_) {}, icon: Icons.share),
-                SlidableAction(onPressed: (_) {}, icon: Icons.delete),
+                SlidableAction(
+                    onPressed: (_) {}, icon: const Icon(Icons.share)),
+                SlidableAction(
+                    onPressed: (_) {}, icon: const Icon(Icons.delete)),
               ],
             ),
             endActionPane: ActionPane(
               key: endActionPaneKey,
               motion: const ScrollMotion(),
               children: [
-                SlidableAction(onPressed: (_) {}, icon: Icons.share),
-                SlidableAction(onPressed: (_) {}, icon: Icons.delete),
+                SlidableAction(
+                    onPressed: (_) {}, icon: const Icon(Icons.share)),
+                SlidableAction(
+                    onPressed: (_) {}, icon: const Icon(Icons.delete)),
               ],
             ),
             child: Builder(builder: (context) {
@@ -213,8 +229,8 @@ void main() {
             key: endActionPaneKey,
             motion: const ScrollMotion(),
             children: [
-              SlidableAction(onPressed: (_) {}, icon: Icons.share),
-              SlidableAction(onPressed: (_) {}, icon: Icons.delete),
+              SlidableAction(onPressed: (_) {}, icon: const Icon(Icons.share)),
+              SlidableAction(onPressed: (_) {}, icon: const Icon(Icons.delete)),
             ],
           ),
           child: Builder(
@@ -253,8 +269,8 @@ void main() {
             key: startActionPaneKey,
             motion: const ScrollMotion(),
             children: [
-              SlidableAction(onPressed: (_) {}, icon: Icons.share),
-              SlidableAction(onPressed: (_) {}, icon: Icons.delete),
+              SlidableAction(onPressed: (_) {}, icon: const Icon(Icons.share)),
+              SlidableAction(onPressed: (_) {}, icon: const Icon(Icons.delete)),
             ],
           ),
           child: Builder(


### PR DESCRIPTION
This PR I would like to add more customize ability to SlidableAction:

- TextStyle
- Icon
- EdgeInsetsGeometry
- OutlinedBorder
- BorderSide

**Screenshot**

![Simulator Screen Shot - iPhone 11 Pro - 2021-11-12 at 15 22 59](https://user-images.githubusercontent.com/42771980/141437726-d78a481f-a674-4d6e-8d4c-f379f9177698.png)


