### PR TITLE
feat: Open ActionPane at the Slidable build time

### DIFF
--- a/lib/src/gesture_detector.dart
+++ b/lib/src/gesture_detector.dart
@@ -77,7 +77,9 @@ class _SlidableGestureDetectorState extends State<SlidableGestureDetector> {
   void handleDragStart(DragStartDetails details) {
     startPosition = details.localPosition;
     lastPosition = startPosition;
-    dragExtent = dragExtent.sign *
+    dragExtent = (widget.controller.ratio != 0 && dragExtent != 0
+            ? dragExtent.sign
+            : widget.controller.ratio.sign) *
         overallDragAxisExtent *
         widget.controller.ratio *
         widget.controller.direction.value;

--- a/lib/src/slidable.dart
+++ b/lib/src/slidable.dart
@@ -27,6 +27,7 @@ class Slidable extends StatefulWidget {
     this.direction = Axis.horizontal,
     this.dragStartBehavior = DragStartBehavior.down,
     this.useTextDirection = true,
+    this.preOpenedActionPane = ActionPaneType.none,
     required this.child,
   }) : super(key: key);
 
@@ -101,6 +102,8 @@ class Slidable extends StatefulWidget {
   /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
+  final ActionPaneType preOpenedActionPane;
+
   @override
   _SlidableState createState() => _SlidableState();
 
@@ -127,6 +130,7 @@ class _SlidableState extends State<Slidable>
   late final SlidableController controller;
   late Animation<Offset> moveAnimation;
   late bool keepPanesOrder;
+  ActionPaneType preOpenedActionPane = ActionPaneType.none;
 
   @override
   bool get wantKeepAlive => !widget.closeOnScroll;
@@ -168,6 +172,16 @@ class _SlidableState extends State<Slidable>
     controller
       ..enableEndActionPane = endActionPane != null
       ..endActionPaneExtentRatio = endActionPane?.extentRatio ?? 0;
+
+    if (widget.preOpenedActionPane != preOpenedActionPane) {
+      preOpenedActionPane = widget.preOpenedActionPane;
+      if (preOpenedActionPane == ActionPaneType.end && endActionPane != null) {
+        controller.ratio = -controller.endActionPaneExtentRatio;
+      } else if (preOpenedActionPane == ActionPaneType.start &&
+          startActionPane != null) {
+        controller.ratio = controller.startActionPaneExtentRatio;
+      }
+    }
   }
 
   void updateIsLeftToRight() {

--- a/lib/src/slidable.dart
+++ b/lib/src/slidable.dart
@@ -102,6 +102,9 @@ class Slidable extends StatefulWidget {
   /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
+  /// Determines the ActionPane that will be opened at the widget's build without animation.
+  ///
+  /// By default, the action pane is [ActionPaneType.none]
   final ActionPaneType preOpenedActionPane;
 
   @override
@@ -227,6 +230,7 @@ class _SlidableState extends State<Slidable>
   }
 
   ActionPane? get startActionPane => widget.startActionPane;
+
   ActionPane? get endActionPane => widget.endActionPane;
 
   Alignment get actionPaneAlignment {


### PR DESCRIPTION
There is required to show Slidable that has 'open' state already at the build time by providing appropriate 'Slidadle'  widget's parameter.

Current behavior right away after build:
![Screenshot_1638516072](https://user-images.githubusercontent.com/32253712/144562633-fdf77003-2bf2-4a1a-adf6-3434664c92df.png)

Required behavior right away after build:
![Screenshot_1638516140](https://user-images.githubusercontent.com/32253712/144562716-102b1d49-2dd5-4c67-9627-f9bec7acf7b3.png)

Usage:

`Slidable(
     preOpenedActionPane: ActionPaneType.start, 
     ......
)         
`