### PR TITLE
Update pub.dev links

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,8 @@
 name: flutter_slidable
 description: A Flutter implementation of slidable list item with directional slide actions that can be dismissed.
 version: 2.0.0
-homepage: https://github.com/letsar/flutter_slidable
+repository: https://github.com/letsar/flutter_slidable
+issue_tracker: https://github.com/letsar/flutter_slidable/issues
 
 environment:
   sdk: '>=2.17.0 <3.0.0'


### PR DESCRIPTION
With this PR, the right section on pub.dev will show the View/report issues link to GitHub again, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).