### PR TITLE
update unused parameter

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -333,7 +333,7 @@ class SlidableController {
   }) async {
     await _animationController.animateTo(
       1,
-      duration: _defaultMovementDuration,
+      duration: duration,
       curve: curve,
     );
     resizeRequest.value = request;


### PR DESCRIPTION
Obviously, `duration` should use the passed in parameters.