### PR TITLE
fix: Scrollable of context for nullable instance

### DIFF
--- a/lib/src/scrolling_behavior.dart
+++ b/lib/src/scrolling_behavior.dart
@@ -58,7 +58,7 @@ class _SlidableScrollingBehaviorState extends State<SlidableScrollingBehavior> {
 
   void addScrollingNotifierListener() {
     if (widget.closeOnScroll) {
-      scrollPosition = Scrollable.of(context)?.position;
+      scrollPosition = Scrollable.maybeOf(context)?.position;
       if (scrollPosition != null) {
         scrollPosition!.isScrollingNotifier.addListener(handleScrollingChanged);
       }


### PR DESCRIPTION
Replace the `Scrollable.of(context)` with `Scrollable.maybeOf(context)` (after updating to Flutter3.7.0 tests are failing).