### PR TITLE
feat: add margin to OutlinedButton

### DIFF
--- a/lib/src/actions.dart
+++ b/lib/src/actions.dart
@@ -101,6 +101,8 @@ class CustomSlidableAction extends StatelessWidget {
       flex: flex,
       child: Container(
         margin: margin,
+        height: double.infinity,
+        width: double.infinity,
         child: OutlinedButton(
           onPressed: () => _handleTap(context),
           style: OutlinedButton.styleFrom(

--- a/lib/src/actions.dart
+++ b/lib/src/actions.dart
@@ -25,6 +25,7 @@ class CustomSlidableAction extends StatelessWidget {
     this.autoClose = _kAutoClose,
     this.borderRadius = BorderRadius.zero,
     this.padding,
+    this.margin,
     required this.onPressed,
     required this.child,
   })  : assert(flex > 0),
@@ -80,6 +81,11 @@ class CustomSlidableAction extends StatelessWidget {
   /// {@endtemplate}
   final EdgeInsets? padding;
 
+  /// {@template slidable.actions.margin}
+  /// The margin of the OutlinedButton
+  /// {@endtemplate}
+  final EdgeInsets? margin;
+
   /// Typically the action's icon or label.
   final Widget child;
 
@@ -93,7 +99,8 @@ class CustomSlidableAction extends StatelessWidget {
 
     return Expanded(
       flex: flex,
-      child: SizedBox.expand(
+      child: Container(
+        margin: margin,
         child: OutlinedButton(
           onPressed: () => _handleTap(context),
           style: OutlinedButton.styleFrom(
@@ -142,6 +149,7 @@ class SlidableAction extends StatelessWidget {
     this.label,
     this.borderRadius = BorderRadius.zero,
     this.padding,
+    this.margin,
   })  : assert(flex > 0),
         assert(icon != null || label != null),
         super(key: key);
@@ -177,6 +185,9 @@ class SlidableAction extends StatelessWidget {
 
   /// Padding of the OutlinedButton
   final EdgeInsets? padding;
+
+  /// Margin of the OutlinedButton
+  final EdgeInsets? margin;
 
   @override
   Widget build(BuildContext context) {
@@ -224,6 +235,7 @@ class SlidableAction extends StatelessWidget {
       backgroundColor: backgroundColor,
       foregroundColor: foregroundColor,
       flex: flex,
+      margin: margin,
       child: child,
     );
   }


### PR DESCRIPTION
Added `margin` property to the `SlidableAction` to allow the slidable to match some of Flutter's other widgets styling. 

I also had to switch from `SizedBox` to `Container` since SizedBoxes are generally used for widgets with fixed sizes. Containers have more flexibility, which is what we need in this situation. This also allows us to implement padding, alignment and other properties in the future.

I had to set both `height` and `width` to `double.infinity` to mimic the `expand` method used with the `SizedBox` that was used earlier.