### PR TITLE
Remove deprecated apis references

### DIFF
--- a/lib/src/actions.dart
+++ b/lib/src/actions.dart
@@ -99,8 +99,8 @@ class CustomSlidableAction extends StatelessWidget {
           style: OutlinedButton.styleFrom(
             padding: padding,
             backgroundColor: backgroundColor,
-            primary: effectiveForegroundColor,
-            onSurface: effectiveForegroundColor,
+            disabledForegroundColor: effectiveForegroundColor.withOpacity(0.38),
+            foregroundColor: effectiveForegroundColor,
             shape: RoundedRectangleBorder(
               borderRadius: borderRadius,
             ),


### PR DESCRIPTION
This PR is to remove 2 references for the deprecated parameters: `OutlinedButton.styleFrom.primary` and `OutlinedButton.styleFrom.onSurface`.

It seems the request review button doesn't work here. So @letsar could you take a look? Thanks a lot:)