### PR TITLE
Document ratio parameter in openTo method

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -302,6 +302,11 @@ class SlidableController {
   }
 
   /// Opens the [Slidable] to the given [ratio].
+  ///
+  /// The [ratio] sign will determine which direction the slidable should open.
+  /// ```dart
+  ///   controller.openTo(-1); //opens slidable all the way to the left side
+  /// ```  
   Future<void> openTo(
     double ratio, {
     Duration duration = _defaultMovementDuration,


### PR DESCRIPTION
Hi, 

I spend an ~~shameful~~ considerate amount of time trying to use the SlidableController.openTo method just to realize that the package was working fine and i just needed to sign the [ratio] parameter.

Would you kindly include the doc comment so the next person dont struggle? 

Thanks in advance,
Great package, btw!