### PR TITLE
fix "A constant constructor can't call a non-constant super constructor." error

### DIFF
--- a/lib/src/flex_entrance_transition.dart
+++ b/lib/src/flex_entrance_transition.dart
@@ -5,7 +5,7 @@ import 'package:flutter/widgets.dart';
 // ignore_for_file: public_member_api_docs
 
 class FlexEntranceTransition extends MultiChildRenderObjectWidget {
-  const FlexEntranceTransition({
+  FlexEntranceTransition({
     super.key,
     required this.mainAxisPosition,
     required this.direction,

--- a/lib/src/flex_exit_transition.dart
+++ b/lib/src/flex_exit_transition.dart
@@ -5,7 +5,7 @@ import 'package:flutter/widgets.dart';
 // ignore_for_file: public_member_api_docs
 
 class FlexExitTransition extends MultiChildRenderObjectWidget {
-  const FlexExitTransition({
+  FlexExitTransition({
     super.key,
     required this.mainAxisExtent,
     required this.direction,


### PR DESCRIPTION
**Working Environment:**

Flutter 3.7.12-ohos • channel unknown • unknown source
Framework • revision acd9aa9121 (35 hours ago) • 2024-08-06 10:37:13 +0800
Engine • revision 1a65d409c7
Tools • Dart 2.19.6 • DevTools 2.20.1

When integrating the library into the project and running it, the `A constant constructor can't call a non-constant super constructor.` error  reported. It's easy to fix. Just remove `const` from the `FlexExitTransition` and `FlexEntranceTransition` classes.
