### PR TITLE
Update icon color & icon size assignment to align with new Flutter 3.27.0 breaking changes

### DIFF
--- a/lib/src/actions.dart
+++ b/lib/src/actions.dart
@@ -134,6 +134,7 @@ class SlidableAction extends StatelessWidget {
     this.flex = _kFlex,
     this.backgroundColor = _kBackgroundColor,
     this.foregroundColor,
+    this.iconSize = 25,
     this.autoClose = _kAutoClose,
     required this.onPressed,
     this.icon,
@@ -162,6 +163,9 @@ class SlidableAction extends StatelessWidget {
   /// An icon to display above the [label].
   final IconData? icon;
 
+  /// The size of the icon, if present.
+  final double? iconSize;
+
   /// The space between [icon] and [label] if both set.
   ///
   /// Defaults to 4.
@@ -182,7 +186,11 @@ class SlidableAction extends StatelessWidget {
 
     if (icon != null) {
       children.add(
-        Icon(icon),
+        Icon(
+          icon,
+          color: foregroundColor,
+          size: iconSize,
+        ),
       );
     }
 


### PR DESCRIPTION
This is just a proof of concept—I've only tested for my own use case. It's intended as an option that closes https://github.com/letsar/flutter_slidable/issues/512.

On closer inspection of Flutter 3.27.0's [ release notes](https://docs.flutter.dev/release/release-notes/release-notes-3.27.0), I saw several mentions of changes to Icons and their properties:
- https://github.com/flutter/flutter/pull/150315
- https://github.com/flutter/flutter/pull/143501
- https://github.com/flutter/flutter/pull/154646
- https://github.com/flutter/flutter/pull/154821

I haven't explored which of these, if any, is relevant, but they gave me an idea. I noticed that flutter_slidable instantiates the SlidableAction `icon` like this ([link](https://github.com/search?q=repo%3Aletsar%2Fflutter_slidable%20Icon(icon)&type=code)):
```dart
Icon(icon);
```

As a test, I forked flutter_slidable and tried explicitly assigning the color and size like this:
```dart
Icon(icon, color: foregroundColor, size: iconSize);
```

where `foregroundColor` is an existing property, and `iconSize` is a property I've added (defaulting to `25.0`).

This yielded an appearance similar to what I observed before these API changes:

### Results

**Appearance in Flutter 3.24.5:**

<img src="https://github.com/user-attachments/assets/52d2b4e7-66c3-42e2-91bf-e0f60600bef3" width="50%">


**Appearance in Flutter 3.27.0 with flutter_slidable v3.1.2:**

<img src="https://github.com/user-attachments/assets/fb69b462-2cbc-4b35-8e27-2db02a0e3d09" width="60%">


**Appearance in Flutter 3.27.0 with flutter_slidable fork w/ modified icon style assignment approach:**

<img src="https://github.com/user-attachments/assets/75621827-aa01-4e5e-ae51-e3c7b69ff9e8" width="27%">


