### PR TITLE
SlidableAction icon color fix for Flutter 3.27.x

### DIFF
--- a/lib/src/actions.dart
+++ b/lib/src/actions.dart
@@ -182,7 +182,7 @@ class SlidableAction extends StatelessWidget {
 
     if (icon != null) {
       children.add(
-        Icon(icon, , color: foregroundColor),
+        Icon(icon, color: foregroundColor),
       );
     }
 

--- a/lib/src/actions.dart
+++ b/lib/src/actions.dart
@@ -182,7 +182,7 @@ class SlidableAction extends StatelessWidget {
 
     if (icon != null) {
       children.add(
-        Icon(icon),
+        Icon(icon, , color: foregroundColor),
       );
     }
 


### PR DESCRIPTION
With the latest Flutter SDK 3.27.x, iconTheme has been modified so that the icon color is not always the same. Should be the same as label or at least configurable.