### PR TITLE
Trigger dismissal when releasing past threshold regardless of gesture direction

### DIFF
--- a/lib/src/actions.dart
+++ b/lib/src/actions.dart
@@ -25,6 +25,7 @@ class CustomSlidableAction extends StatelessWidget {
     this.autoClose = _kAutoClose,
     this.borderRadius = BorderRadius.zero,
     this.padding,
+    this.alignment,
     required this.onPressed,
     required this.child,
   }) : assert(flex > 0);
@@ -79,6 +80,13 @@ class CustomSlidableAction extends StatelessWidget {
   /// {@endtemplate}
   final EdgeInsets? padding;
 
+  /// {@template slidable.actions.alignment}
+  /// The alignment of the child within the button.
+  ///
+  /// Defaults to [Alignment.center].
+  /// {@endtemplate}
+  final Alignment? alignment;
+
   /// Typically the action's icon or label.
   final Widget child;
 
@@ -96,7 +104,9 @@ class CustomSlidableAction extends StatelessWidget {
         child: OutlinedButton(
           onPressed: () => _handleTap(context),
           style: OutlinedButton.styleFrom(
-            padding: padding,
+            padding: padding ?? EdgeInsets.zero,
+            minimumSize: Size.zero,
+            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
             backgroundColor: backgroundColor,
             disabledForegroundColor: effectiveForegroundColor.withValues(
               alpha: 0.38,
@@ -108,7 +118,10 @@ class CustomSlidableAction extends StatelessWidget {
             ),
             side: BorderSide.none,
           ),
-          child: child,
+          child: Align(
+            alignment: alignment ?? Alignment.center,
+            child: child,
+          ),
         ),
       ),
     );
@@ -144,6 +157,7 @@ class SlidableAction extends StatelessWidget {
     this.label,
     this.borderRadius = BorderRadius.zero,
     this.padding,
+    this.alignment,
   })  : assert(flex > 0),
         assert(icon != null || label != null);
 
@@ -178,6 +192,9 @@ class SlidableAction extends StatelessWidget {
 
   /// Padding of the OutlinedButton
   final EdgeInsets? padding;
+
+  /// {@macro slidable.actions.alignment}
+  final Alignment? alignment;
 
   @override
   Widget build(BuildContext context) {
@@ -220,6 +237,7 @@ class SlidableAction extends StatelessWidget {
     return CustomSlidableAction(
       borderRadius: borderRadius,
       padding: padding,
+      alignment: alignment,
       onPressed: onPressed,
       autoClose: autoClose,
       backgroundColor: backgroundColor,

--- a/lib/src/dismissible_pane.dart
+++ b/lib/src/dismissible_pane.dart
@@ -123,8 +123,8 @@ class _DismissiblePaneState extends State<DismissiblePane> {
     final endGesture = controller!.dismissGesture.value!.endGesture;
     final position = controller!.animation.value;
 
-    if (endGesture is OpeningGesture && position >= widget.dismissThreshold ||
-        endGesture is StillGesture && position >= widget.dismissThreshold) {
+    // If we're currently past the threshold, trigger the action regardless of gesture type
+    if (position >= widget.dismissThreshold) {
       bool canDismiss = true;
       if (widget.confirmDismiss != null) {
         canDismiss = await widget.confirmDismiss!();


### PR DESCRIPTION
## Description
This PR fixes an issue where `DismissiblePane` would cancel a dismissal and settle into the open action pane state if the finger moved backward before lifting, even when releasing well past the threshold. This is particularly problematic during rapid repeated swipes on multiple items.

## Problem
Users expect that once they swipe past the dismissal threshold, the action will execute when they release, similar to native iOS behavior. However, the current implementation cancels the dismiss if the finger moves backward before lifting - which commonly happens during rapid repeated swipes. This leaves the action pane open instead of executing the dismiss, requiring additional user interaction.

<p align="center">
  <img src="https://github.com/user-attachments/assets/27fd28a4-131a-4452-9395-5ae0f008dcd4" alt="Interaction demo" width="250">
</p>

## Solution
Simplified the logic in `handleDismissGestureChanged` to check only if the current position is past the threshold when the gesture ends. If it is, the dismissal proceeds regardless of the gesture type.

<p align="center">
  <img src="https://github.com/user-attachments/assets/0387c1e6-d99a-4850-8f69-ceb55a3cf2fe" alt="Interaction demo" width="250">
</p>

## Changes
- Modified `handleDismissGestureChanged` in `dismissible_pane.dart` to check current position against threshold
- Removed gesture type conditions that could prevent dismissal when past threshold

## Testing
- Tested with rapid repeated swipes on multiple items
- Verified that releasing past threshold always triggers the dismiss action
- Confirmed that releasing before threshold still opens the action pane as expected

Fixes #536