### PR TITLE
Add function usage hint for controller dismiss method.

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -355,6 +355,7 @@ class SlidableController {
   }
 
   /// Dismisses the [Slidable].
+  /// When used inside a [SlidableAction], [autoClose] needs to be set to false
   Future<void> dismiss(
     ResizeRequest request, {
     Duration duration = _defaultMovementDuration,


### PR DESCRIPTION
I see that in #326, the `SlidableController.dismiss` method does not work inside a `SlidableAction` widget by default. This pull requests simply adds hint on enabling intended behavior.